### PR TITLE
fix: logging panic or fatal in async may skip sending the log to splunk

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -35,7 +35,7 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 	if err != nil {
 		return err
 	}
-	if h.async {
+	if h.async && entry.Level > logrus.FatalLevel {
 		go func() {
 			err = h.Client.Log(preparedEntry, h.retries)
 			if err != nil {


### PR DESCRIPTION
When logging fatal or panic the program will try to exit and this can happens faster than loggin to splunk